### PR TITLE
Voice QoL

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ You can enable VC-related commands such as `/voice play` (which plays videos fro
 
 Activate voice by placing `Lavalink.jar` from lavalink releases and rename `application.yml.template` to `application.yml` and run `java -jar Lavalink.jar` in separate session before starting the bot.
 
+Alternatively, you can use the servers from You can skip the installation step above and use servers from https://lavalink.darrennathanael.com/NoSSL/lavalink-without-ssl/ and configure the `dev.env` file pointing the third party Lavalink servers, no installation required... Please see [CONFIG.md#voice](./docs/CONFIG.md#voice)
+
 ## Running the server
 After everything is configured, you can run `main.py`
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Core dependencies is Python with PIP, depending on your distribution, pip must b
 
 ### Optional dependencies
 - OpenJDK 17 with ffmpeg \
-    Needed for voice commands (wavelink/lavalink)
+    Needed for voice commands (wavelink/lavalink) if needing to self-host lavalink server
 
 There may be other dependencies needed for some operations such as tools. Please see [TOOLS.md](./docs/TOOLS.md) for rationale.
 
@@ -62,11 +62,14 @@ Required fields to configure:
 Please see [CONFIG.md](./docs/CONFIG.md) for more information about configuration.
 
 ### Voice commands configuration:
+#### Your own LavaLink server
 You can enable VC-related commands such as `/voice play` (which plays videos from YouTube and other supported sources) by downloading [Lavalink jar file](https://github.com/lavalink-devs/Lavalink/releases) and placing it as `wavelink/Lavalink.jar` in project's root directory.
 
 Activate voice by placing `Lavalink.jar` from lavalink releases and rename `application.yml.template` to `application.yml` and run `java -jar Lavalink.jar` in separate session before starting the bot.
 
-Alternatively, you can use the servers from You can skip the installation step above and use servers from https://lavalink.darrennathanael.com/NoSSL/lavalink-without-ssl/ and configure the `dev.env` file pointing the third party Lavalink servers, no installation required... Please see [CONFIG.md#voice](./docs/CONFIG.md#voice)
+---
+#### Serverless lavalink
+Alternatively, you can use the list of 3rd party servers from and use servers from https://lavalink.darrennathanael.com/NoSSL/lavalink-without-ssl/ and skip the installation step above and configure the `dev.env` file pointing the third party Lavalink servers, no installation required... Please see [CONFIG.md#voice](./docs/CONFIG.md#voice) for more information.
 
 ## Running the server
 After everything is configured, you can run `main.py`

--- a/_wavelink/application.yml.template
+++ b/_wavelink/application.yml.template
@@ -12,7 +12,7 @@ plugins:
     clients: ["MUSIC", "ANDROID_TESTSUITE", "WEB"]
 lavalink:
   plugins:
-    - dependency: "dev.lavalink.youtube:youtube-plugin:1.4.0"
+    - dependency: "dev.lavalink.youtube:youtube-plugin:1.5.2"
       snapshot: false
   server:
     password: "youshallnotpass"

--- a/cogs/voice.py
+++ b/cogs/voice.py
@@ -1,13 +1,14 @@
 from discord.commands import SlashCommandGroup
 from discord.ext import commands
 import discord
+import typing
 import wavelink
 
 # For now everything is taken from https://pypi.org/project/WavelinkPycord/ but "class"ified bad pun intended
 class Voice(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.current_user = None
+        self.current_user = {}
 
     voice = SlashCommandGroup("voice", "Access voice features!", contexts={discord.InteractionContextType.guild})
 
@@ -19,32 +20,22 @@ class Voice(commands.Cog):
     )
     async def play(self, ctx, search: str):
         """Play music or audio from YouTube, enter a search query or a YouTube URL to play"""
+        vc = typing.cast(wavelink.Player, ctx.voice_client)
 
-        if hasattr(ctx, "voice_client") and hasattr(ctx.author.voice, "channel"):
-            if ctx.voice_client:
-                vc: wavelink.Player = ctx.voice_client
-                # If the bot is connected to a different channel than the user, disconnect and connect to the user's channel
-                if vc.channel != ctx.author.voice.channel:
-                    #if hasattr(vc, "playing") and vc.playing or hasattr(vc, "paused") and vc.paused:
-                    #    await vc.stop()
-                    #await vc.disconnect()
-                    #vc: wavelink.Player = await ctx.author.voice.channel.connect(cls=wavelink.Player)
-                    # That code is buggy, has higher delay bug so for now, we prompt the user to move to another voice channel where it originally started
-                    await ctx.respond("⚠️ Please move to the voice channel where the bot is currently playing.")
-                    return
-            else:
-                vc: wavelink.Player = await ctx.author.voice.channel.connect(cls=wavelink.Player)   
-        else:
-            return await ctx.respond('🎤 Please join a voice channel.')
+        if not vc:
+            vc = await ctx.author.voice.channel.connect(cls=wavelink.Player)
 
         # Check if there is a playback on the voice client, otherwise, clear the current user record
-        if self.current_user is not None and hasattr(vc, "playing") or hasattr(vc, "paused"):
+        if self.current_user.get(ctx.guild.id) is not None and hasattr(vc, "playing") or hasattr(vc, "paused"):
             if vc.playing or vc.paused:
                 if ctx.author.guild_permissions.administrator == False and ctx.guild.owner_id != ctx.author.id:
-                    if self.current_user != ctx.author.id:
+                    if self.current_user.get(ctx.guild.id) != ctx.author.id:
                         return await ctx.respond('⚠️ You are not the one who queued this track.')
         else:
-            self.current_user = None
+            self.current_user.update({ctx.guild.id: None})
+
+        if ctx.author.voice.channel.id != vc.channel.id:
+            return await ctx.respond("🎙️ You must be in the same voice channel as the bot.")
 
         # Search for tracks using the given query and assign it to the tracks variable
         try:
@@ -68,19 +59,19 @@ class Voice(commands.Cog):
         # For moral purposes
 
         # Set the user currently playing the track to the class-level variable
-        self.current_user = ctx.author.id
+        self.current_user.update({ctx.guild.id: ctx.author.id})
 
     @voice.command()
     async def status(self, ctx):
         """Get status of the currently playing track or queue"""
-        vc: wavelink.Player = ctx.voice_client
+        vc = typing.cast(wavelink.Player, ctx.voice_client)
     
         # Check for playback
-        if not hasattr(vc, "playing") or not hasattr(vc.current, "title"):
+        if not vc and not hasattr(vc, "playing") or not hasattr(vc.current, "title"):
             await ctx.respond("❌ You are not playing any tracks!")
             return
 
-        user = await self.bot.fetch_user(self.current_user)
+        user = await self.bot.fetch_user(self.current_user.get(ctx.guild.id))
         avatar_url = user.avatar.url if user.avatar else "https://cdn.discordapp.com/embed/avatars/0.png"
 
         embed = discord.Embed(
@@ -114,10 +105,10 @@ class Voice(commands.Cog):
     @voice.command()
     async def ping(self, ctx):
         """Pings the wavelink.Player server for latency"""
-        vc: wavelink.Player = ctx.voice_client
+        vc = typing.cast(wavelink.Player, ctx.voice_client)
 
         # Check if there's even a voice client connected
-        if not hasattr(vc, "connected"):
+        if not vc and not hasattr(vc, "connected"):
             return await ctx.respond('🎙️ Not currently connected to a voice channel.')
 
         # Check ping
@@ -130,11 +121,11 @@ class Voice(commands.Cog):
     )
     async def pause(self, ctx):
         """Pause the currently playing track"""
-        vc: wavelink.Player = ctx.voice_client
+        vc = typing.cast(wavelink.Player, ctx.voice_client)
 
         # We are not rude people
         if ctx.author.guild_permissions.administrator == False and ctx.guild.owner_id != ctx.author.id:
-            if self.current_user != ctx.author.id:
+            if self.current_user.get(ctx.guild.id) != ctx.author.id:
                 return await ctx.respond('🛑 You are not the one who queued this track.')
                 
         # Check if there's even a voice client connected
@@ -151,11 +142,11 @@ class Voice(commands.Cog):
     @voice.command()
     async def resume(self, ctx):
         """Resume the currently paused track"""
-        vc: wavelink.Player = ctx.voice_client
+        vc = typing.cast(wavelink.Player, ctx.voice_client)
 
         # We are not rude people
         if ctx.author.guild_permissions.administrator == False and ctx.guild.owner_id != ctx.author.id:
-            if self.current_user != ctx.author.id:
+            if self.current_user.get(ctx.guild.id) != ctx.author.id:
                 return await ctx.respond('You are not the one who queued this track.')
 
         # Check if there's even a voice client connected
@@ -171,15 +162,15 @@ class Voice(commands.Cog):
     @voice.command()
     async def stop(self, ctx):
         """Stop the currently playing or paused track"""
-        vc: wavelink.Player = ctx.voice_client
+        vc = typing.cast(wavelink.Player, ctx.voice_client)
 
         # Lets not be selfish and allow the user who queued the track to stop it... Only the guild owner can stop the track in case he playing porn or something
         if ctx.author.guild_permissions.administrator == False and ctx.guild.owner_id != ctx.author.id:
-            if self.current_user != ctx.author.id:
+            if self.current_user.get(ctx.guild.id) != ctx.author.id:
                 return await ctx.respond('🎤 You are not the one who queued this track.')
 
         # Check if there's even a voice client connected
-        if not hasattr(vc, "connected"):
+        if not vc and not hasattr(vc, "connected"):
             return await ctx.respond('🎙️ Not currently connected to a voice channel.')
 
         # Store the title in the variable before stopping the track to notifiy the user since once it's stopped, vc.current.title will be None
@@ -190,15 +181,15 @@ class Voice(commands.Cog):
     @voice.command()
     async def disconnect(self, ctx):
         """Disconnects the bot from wavelink.Player and removes from the voice channel"""
-        vc: wavelink.Player = ctx.voice_client
+        vc = typing.cast(wavelink.Player, ctx.voice_client)
 
         # Disconnect only if the user initiated the connection, server administrator or the guild owner
         if ctx.author.guild_permissions.administrator == False and ctx.guild.owner_id != ctx.author.id:
-            if self.current_user != ctx.author.id:
+            if self.current_user.get(ctx.guild.id) != ctx.author.id:
                 return await ctx.respond('You are not the one who queued this track or has insufficent admin permissions to do this.')
 
         # Check if there's even a voice client connected
-        if not hasattr(vc, "connected"):
+        if not vc and not hasattr(vc, "connected"):
             return await ctx.respond('🎙️ Not currently connected to a voice channel.')
 
         # Check if we are playing a track before disconnecting

--- a/cogs/voice.py
+++ b/cogs/voice.py
@@ -20,10 +20,14 @@ class Voice(commands.Cog):
     )
     async def play(self, ctx, search: str):
         """Play music or audio from YouTube, enter a search query or a YouTube URL to play"""
+        await ctx.response.defer()
         vc = typing.cast(wavelink.Player, ctx.voice_client)
 
-        if not vc:
-            vc = await ctx.author.voice.channel.connect(cls=wavelink.Player)
+        try:
+            if not vc:
+                vc = await ctx.author.voice.channel.connect(cls=wavelink.Player)
+        except AttributeError:
+            return await ctx.respond("🎙️ You must be in a voice channel to use this command.")
 
         # Check if there is a playback on the voice client, otherwise, clear the current user record
         if self.current_user.get(ctx.guild.id) is not None and hasattr(vc, "playing") or hasattr(vc, "paused"):

--- a/dev.env.template
+++ b/dev.env.template
@@ -1,9 +1,9 @@
 TOKEN = INSERT_DISCORD_TOKEN
 
 # Lavalink Environment Variables
-ENV_LAVALINK_HOST = 127.0.0.1
-ENV_LAVALINK_PORT = 2222
+ENV_LAVALINK_URI = "http://127.0.0.1:2222"
 ENV_LAVALINK_PASS = "youshallnotpass"
+ENV_LAVALINK_IDENTIFIER = "main"
 
 # Google AI Studio API token
 GOOGLE_AI_TOKEN = "INSERT_API_KEY"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -12,7 +12,7 @@ Enabling plugins other than YouTube is not recommended as its optimized for YouT
 
 You can skip the installation step above and use servers from https://lavalink.darrennathanael.com/NoSSL/lavalink-without-ssl/
 
-- `ENV_LAVALINK_HOST` - Host where Lavalink server is running (defaults to local server URI: `http://127.0.0.1:2222`)
+- `ENV_LAVALINK_URI` - Host where Lavalink server is running (defaults to local server URI: `http://127.0.0.1:2222`)
    `ENV_LAVALINK_PASS` - Lavalink password (change this if connecting remotely) - (defaults to "youshallnotpass")
 - `ENV_LAVALINK_IDENTIFIER` - Lavalink identifier (optional, used for some servers that has it, defaults to `main`)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,18 +1,24 @@
 # Configuration
+## Bot
 This document defines the `dev.env` variables used to configure the Discord bot. To get started, copy `dev.env.template` file to `dev.env`.
 
 - `TOKEN` - Set the Discord bot token, get one from [Discord Developer Portal](https://discord.com/developers/applications).
+
+## Voice
 
 These are the default settings to connect to Lavalink v4. If you're willing to use different host, port, and password, please make a copy of [wavelink/application.yml.template](./wavelink/application.yml.template) to `wavelink/application.yml` and change the settings accordingly. Please configure Lavalink's yml file if you want to use proxy, changing the server port, password and so on.
 
 Enabling plugins other than YouTube is not recommended as its optimized for YouTube playback.
 
-- `ENV_LAVALINK_HOST` - Host where Lavalink server is running (defaults to local server: 127.0.0.1)
-- `ENV_LAVALINK_PORT` - Lavalink port number (defaults to 2222)
-- `ENV_LAVALINK_PASS` - Lavalink password (change this if connecting remotely) - (defaults to "youshallnotpass")
+You can skip the installation step above and use servers from https://lavalink.darrennathanael.com/NoSSL/lavalink-without-ssl/
 
-Please do not use this module in production unless you're serving it yourself or other remote content than YouTube.
+- `ENV_LAVALINK_HOST` - Host where Lavalink server is running (defaults to local server URI: `http://127.0.0.1:2222`)
+   `ENV_LAVALINK_PASS` - Lavalink password (change this if connecting remotely) - (defaults to "youshallnotpass")
+- `ENV_LAVALINK_IDENTIFIER` - Lavalink identifier (optional, used for some servers that has it, defaults to `main`)
 
+Please do not use this module in production unless you're serving it yourself or other remote content than YouTube. Never verify your bot with YouTube playback or you'll risk violating terms in both parties.
+
+## Misc
 - `GOOGLE_AI_TOKEN` - Set the Gemini API token, get one at [Google AI Studio](https://aistudio.google.com/app/apikey). If left blank, generative features will be disabled.
 
 - `SYSTEM_USER_ID` - If you're hosting a bot, please set your Discord user ID to adminisrate the bot even if you're not the administrator of the server. With great power coems great responsibility! This is used for commands like `$admin_execute` (`$eval` as alias) to do tasks like `$eval git pull --rebase` or `$eval free -h`

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -13,7 +13,7 @@ Enabling plugins other than YouTube is not recommended as its optimized for YouT
 You can skip the installation step above and use servers from https://lavalink.darrennathanael.com/NoSSL/lavalink-without-ssl/
 
 - `ENV_LAVALINK_URI` - Host where Lavalink server is running (defaults to local server URI: `http://127.0.0.1:2222`)
-   `ENV_LAVALINK_PASS` - Lavalink password (change this if connecting remotely) - (defaults to "youshallnotpass")
+- `ENV_LAVALINK_PASS` - Lavalink password (change this if connecting remotely) - (defaults to "youshallnotpass")
 - `ENV_LAVALINK_IDENTIFIER` - Lavalink identifier (optional, used for some servers that has it, defaults to `main`)
 
 Please do not use this module in production unless you're serving it yourself or other remote content than YouTube. Never verify your bot with YouTube playback or you'll risk violating terms in both parties.

--- a/main.py
+++ b/main.py
@@ -48,13 +48,13 @@ bot = bridge.Bot(command_prefix=commands.when_mentioned_or("$"), intents = inten
 async def wavelink_setup():
     await bot.wait_until_ready()
     # https://wavelink.dev/en/latest/recipes.html
-    ENV_LAVALINK_HOST = environ.get("ENV_LAVALINK_HOST") if environ.get("ENV_LAVALINK_HOST") is not None else "0.0.0.0"
-    ENV_LAVALINK_PORT = environ.get("ENV_LAVALINK_PORT") if environ.get("ENV_LAVALINK_PORT") is not None else "2333"
+    ENV_LAVALINK_URI = environ.get("ENV_LAVALINK_URI") if environ.get("ENV_LAVALINK_URI") is not None else "http://127.0.0.1:2222"
     ENV_LAVALINK_PASS = environ.get("ENV_LAVALINK_PASS") if environ.get("ENV_LAVALINK_PASS") is not None else "youshallnotpass"
+    ENV_LAVALINK_IDENTIFIER = environ.get("ENV_LAVALINK_IDENTIFIER") if environ.get("ENV_LAVALINK_IDENTIFIER") is not None else "main"
 
     node = wavelink.Node(
-        identifier="main",
-        uri=f"http://{ENV_LAVALINK_HOST}:{ENV_LAVALINK_PORT}",
+        identifier=ENV_LAVALINK_IDENTIFIER,
+        uri=ENV_LAVALINK_URI,
         password=ENV_LAVALINK_PASS
     )
 

--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ async def wavelink_setup():
 
     node = wavelink.Node(
         identifier="main",
-        uri=f"ws://{ENV_LAVALINK_HOST}:{ENV_LAVALINK_PORT}",
+        uri=f"http://{ENV_LAVALINK_HOST}:{ENV_LAVALINK_PORT}",
         password=ENV_LAVALINK_PASS
     )
 

--- a/main.py
+++ b/main.py
@@ -53,6 +53,7 @@ async def wavelink_setup():
     ENV_LAVALINK_PASS = environ.get("ENV_LAVALINK_PASS") if environ.get("ENV_LAVALINK_PASS") is not None else "youshallnotpass"
 
     node = wavelink.Node(
+        identifier="main",
         uri=f"ws://{ENV_LAVALINK_HOST}:{ENV_LAVALINK_PORT}",
         password=ENV_LAVALINK_PASS
     )


### PR DESCRIPTION
- Better user handling per guild instead of globally assigning it `self.current_user`
- Update documentations for using 3rd party lavalink servers
- Replace `ENV_LAVALINK_{HOST,PORT}` with `ENV_LAVALINK_URI` instead, accepting `http://host:port` syntax. Defaults remains unchanged
- Add optional `ENV_LAVALINK_IDENTIFIER` which passes the identifier parameter to lavalink, some servers may have specific identifiers set